### PR TITLE
Update Docker Compose and README to reflect new database name 'taigu'…

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,6 @@ make start
 docker cp ~/db-backups/backup.sql taigu-db-1:/backup.sql
 make shell-db
     # In the db container:
-    psql trade_smartly < /backup.sql
+    psql taigu < /backup.sql
     exit
 ```

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -74,7 +74,7 @@ services:
       - PGUSER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres # for default, the application doesn't use this
-      - APP_DB=trade_smartly
+      - APP_DB=taigu
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -69,7 +69,7 @@ services:
       - PGUSER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres # for default, the application doesn't use this
-      - APP_DB=trade_smartly
+      - APP_DB=taigu
     restart: unless-stopped
     logging:
       driver: "json-file"


### PR DESCRIPTION
… (#62)

- Changed the database name in both development and production Docker Compose files from 'trade_smartly' to 'taigu'.
- Updated the README instructions to use 'taigu' for database restoration commands, ensuring consistency with the new naming convention.