### PR TITLE
Add GitHub Actions workflow for building and pushing production images

### DIFF
--- a/.github/workflows/build-and-push-production-images.yaml
+++ b/.github/workflows/build-and-push-production-images.yaml
@@ -1,0 +1,22 @@
+name: Build and push production images
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push-production-images:
+    runs-on: ubuntu-24.04-arm
+    environment: Build
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build
+        run: make build-prod
+      - name: Push
+        run: make push-images-prod

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -20,8 +20,7 @@ load_env_vars() {
     if [ -f .env ]; then
         export $(cat .env | grep -v '^#' | xargs)
     else
-        printf "${RED}Error: .env file not found${RESET}\n"
-        exit 1
+        printf "${YELLOW}Warning: .env file not found, using default values${RESET}\n"
     fi
 }
 

--- a/scripts/dev/push-images.sh
+++ b/scripts/dev/push-images.sh
@@ -4,7 +4,6 @@ set -e
 source "$(dirname "$(realpath "$0")")/../common.sh"
 
 check_triggered_by_make
-check_env dev
 load_env_vars
 
 if [ "$1" != "dev" ] && [ "$1" != "prod" ]; then


### PR DESCRIPTION
- Introduced a new workflow in `.github/workflows/build-and-push-production-images.yaml` to automate the building and pushing of production Docker images.
- Configured the workflow to trigger on pushes to the main branch and manual dispatch.
- Set up environment variables for Docker credentials and included steps for code checkout, building the production image, and pushing it to the registry.

- Updated `load_env_vars` function in `scripts/common.sh` to issue a warning instead of an error when the `.env` file is not found, allowing for default values to be used.

- Removed the `check_env dev` call from `scripts/dev/push-images.sh` to streamline the script execution process.